### PR TITLE
SECURITY-1298: Reenable KerberosAuthentication to allow auth for host…

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,7 +12,7 @@ profile_allow_ssh_from_bastion::bastion_nodelist:
   - "141.142.148.24"
 profile_allow_ssh_from_bastion::custom_cfg:
   GSSAPIAuthentication: "yes"
-  KerberosAuthentication: "no"
+  KerberosAuthentication: "yes"
   PasswordAuthentication: "yes"
   PubkeyAuthentication: "no"
 profile_allow_ssh_from_bastion::groups:


### PR DESCRIPTION
…s without kerberos hostkeys

This is currently being tested on `glick-pup`.