### PR TITLE
Set hiera lookup_options back to default

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,10 +1,4 @@
 ---
-lookup_options:
-  profile_allow_ssh_from_bastion::groups:
-    merge: "unique"
-  profile_allow_ssh_from_bastion::users:
-    merge: "unique"
-
 profile_allow_ssh_from_bastion::bastion_nodelist:
   - "141.142.148.5"
   - "141.142.236.22"


### PR DESCRIPTION
See SVC-4509 for details, but setting the hiera lookup_options for
profile_allow_ssh_from_bastion::groups:
and
profile_allow_ssh_from_bastion::users:
back to the default behavior will make it easier for projects to make
adjustments