### PR TITLE
SECURITY-1421 Explicitly set AuthenticationMethods

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -5,6 +5,7 @@ profile_allow_ssh_from_bastion::bastion_nodelist:
   - "141.142.236.23"
   - "141.142.148.24"
 profile_allow_ssh_from_bastion::custom_cfg:
+  AuthenticationMethods: "gssapi-with-mic password"
   GSSAPIAuthentication: "yes"
   KerberosAuthentication: "no"
   PasswordAuthentication: "yes"


### PR DESCRIPTION
Setting them in the match block so that we can eventually set
AuthenticationMethods None
in the global config